### PR TITLE
[codex] Support /objectives/ index URL

### DIFF
--- a/docs/main.py
+++ b/docs/main.py
@@ -1,5 +1,18 @@
 import re
 
+from mkdocs.structure.nav import _add_parent_links, _add_previous_and_next_links
+from mkdocs.structure.pages import Page
+
+OBJECTIVES_SECTION_TITLE = "Objectives"
+PLURAL_OBJECTIVES_INDEX = "objectives/index.md"
+SINGULAR_OBJECTIVE_INDEX = "objective/index.md"
+
+
+def _nav_item_src_uri(item):
+    file = getattr(item, "file", None)
+    return getattr(file, "src_uri", None)
+
+
 def define_env(env):
     "Hook function"
 
@@ -12,38 +25,85 @@ def define_env(env):
         return list
 
 
+def on_nav(nav, config, files):
+    """Use /objectives/ as the Objective section index."""
+    objectives_file = files.get_file_from_path(PLURAL_OBJECTIVES_INDEX)
+    if objectives_file is None:
+        return nav
+
+    objective_section = next(
+        (
+            item
+            for item in nav.items
+            if getattr(item, "is_section", False) and item.title == OBJECTIVES_SECTION_TITLE
+        ),
+        None,
+    )
+    if objective_section is None:
+        return nav
+
+    objectives_page = objectives_file.page or Page("Objectives", objectives_file, config)
+    objectives_page.title = OBJECTIVES_SECTION_TITLE
+
+    hidden_section_indexes = {PLURAL_OBJECTIVES_INDEX, SINGULAR_OBJECTIVE_INDEX}
+    objective_section.children = [
+        child
+        for child in objective_section.children
+        if _nav_item_src_uri(child) not in hidden_section_indexes
+    ]
+    nav.pages = [
+        page
+        for page in nav.pages
+        if page is not objectives_page and _nav_item_src_uri(page) != SINGULAR_OBJECTIVE_INDEX
+    ]
+
+    objective_section.children.insert(0, objectives_page)
+    nav.pages.insert(1, objectives_page)
+
+    _add_previous_and_next_links(nav.pages)
+    _add_parent_links(nav.items)
+
+    return nav
+
+
 def on_page_content(html, page, config, files):
     """
     Inject objective letter badge before the first H1 heading.
     This runs after markdown is converted to HTML.
     """
     # Check if page has letter_prefix in frontmatter
-    if not hasattr(page, 'meta') or 'letter_prefix' not in page.meta:
+    if not hasattr(page, "meta") or "letter_prefix" not in page.meta:
         return html
-    
-    letter_prefix = page.meta['letter_prefix']
+
+    letter_prefix = page.meta["letter_prefix"]
     if not letter_prefix or not isinstance(letter_prefix, str):
         return html
-    
+
     # Find the first H1 tag and wrap it with the badge
     # Pattern: <h1 ... > ... </h1>
-    h1_pattern = r'(<h1[^>]*>)(.*?)(</h1>)'
-    
+    h1_pattern = r"(<h1[^>]*>)(.*?)(</h1>)"
+
     def replace_first_h1(match):
         opening_tag = match.group(1)
         h1_content = match.group(2)
         closing_tag = match.group(3)
-        
+
         # Create the badge wrapper HTML
-        badge_html = f'''<div class="objective-header-with-badge">
+        badge_html = f"""<div class="objective-header-with-badge">
 <span class="objective-badge-standalone" data-letter="{letter_prefix}"></span>
 
 {opening_tag}{h1_content}{closing_tag}
 
-</div>'''
+</div>"""
         return badge_html
-    
+
     # Replace only the first H1
-    modified_html = re.sub(h1_pattern, replace_first_h1, html, count=1, flags=re.DOTALL)
-    
+    modified_html = re.sub(
+        h1_pattern,
+        replace_first_h1,
+        html,
+        count=1,
+        flags=re.DOTALL,
+    )
+
     return modified_html

--- a/docs/objectives/index.md
+++ b/docs/objectives/index.md
@@ -1,0 +1,111 @@
+---
+title: Objectives
+description: >-
+  Discover the primary objectives for creating a Use Case Tree in the Use Case
+  Tree Method. Learn how interoperability, composability, reuse, and other
+  objectives drive enterprise knowledge graph success.
+keywords:
+  - EKG objectives
+  - use case tree objectives
+  - enterprise knowledge graph goals
+  - EKG method
+  - business objectives
+schema_type: "WebPage"
+---
+
+<!-- markdownlint-disable MD013 MD033 -->
+
+# Objectives
+
+The primary reasons for creating a
+[Use Case Tree](../concept/use-case-tree.md) are:
+
+<!--objectives-index-start-->
+
+![Conveyer Belt](../assets/conveyer-belt.jpg)[^copyright]
+
+<div class="grid cards" markdown>
+
+- <span class="objective-badge" data-letter="A"></span> __Interoperability Achieved__
+
+    {% include-markdown "objective/interoperability.md"
+    start="<!--summary-start-->" end="<!--summary-end-->" %}
+    [:octicons-arrow-right-24: Learn more](../objective/interoperability.md)
+
+- <span class="objective-badge" data-letter="B"></span> __Business Composability Improved__
+
+    {% include-markdown "objective/composable-business.md"
+    start="<!--summary-start-->" end="<!--summary-end-->" %}
+    [:octicons-arrow-right-24: Learn more](../objective/composable-business.md)
+
+- <span class="objective-badge" data-letter="C"></span> __Requirements Captured__
+
+    {% include-markdown "objective/know-what-the-business-wants.md"
+    start="<!--summary-start-->" end="<!--summary-end-->" %}
+    [:octicons-arrow-right-24: Learn more](../objective/know-what-the-business-wants.md)
+
+- <span class="objective-badge" data-letter="D"></span> __Knowledge Captured__
+
+    {% include-markdown "objective/capture-knowledge.md"
+    start="<!--summary-start-->" end="<!--summary-end-->" %}
+    [:octicons-arrow-right-24: Learn more](../objective/capture-knowledge.md)
+
+- <span class="objective-badge" data-letter="E"></span> __Gaps Bridged__
+
+    {% include-markdown "objective/bridge-the-gap.md"
+    start="<!--summary-start-->" end="<!--summary-end-->" %}
+    [:octicons-arrow-right-24: Learn more](../objective/bridge-the-gap.md)
+
+- <span class="objective-badge" data-letter="F"></span> __Expectations Managed__
+
+    {% include-markdown "objective/manage-expectations.md"
+    start="<!--summary-start-->" end="<!--summary-end-->" %}
+    [:octicons-arrow-right-24: Learn more](../objective/manage-expectations.md)
+
+- <span class="objective-badge" data-letter="G"></span> __Did not boil the ocean__
+
+    {% include-markdown "objective/avoid-boiling-the-ocean.md"
+    start="<!--summary-start-->" end="<!--summary-end-->" %}
+    [:octicons-arrow-right-24: Learn more](../objective/avoid-boiling-the-ocean.md)
+
+- <span class="objective-badge" data-letter="H"></span> __Disruption Avoided__
+
+    {% include-markdown "objective/avoid-disruption.md"
+    start="<!--summary-start-->" end="<!--summary-end-->" %}
+    [:octicons-arrow-right-24: Learn more](../objective/avoid-disruption.md)
+
+- <span class="objective-badge" data-letter="I"></span> __Quality Increased__
+
+    {% include-markdown "objective/increase-quality.md"
+    start="<!--summary-start-->" end="<!--summary-end-->" %}
+    [:octicons-arrow-right-24: Learn more](../objective/increase-quality.md)
+
+- <span class="objective-badge" data-letter="J"></span> __Aligned with Strategy__
+
+    {% include-markdown "objective/align-with-business-strategy.md"
+    start="<!--summary-start-->" end="<!--summary-end-->" %}
+    [:octicons-arrow-right-24: Learn more](../objective/align-with-business-strategy.md)
+
+- <span class="objective-badge" data-letter="K"></span> __Delivered__
+
+    {% include-markdown "objective/strategic-usecases.md"
+    start="<!--summary-start-->" end="<!--summary-end-->" %}
+    [:octicons-arrow-right-24: Learn more](../objective/strategic-usecases.md)
+
+- <span class="objective-badge" data-letter="L"></span> __Modularity Managed__
+
+    {% include-markdown "objective/modularity.md"
+    start="<!--summary-start-->" end="<!--summary-end-->" %}
+    [:octicons-arrow-right-24: Learn more](../objective/modularity.md)
+
+- <span class="objective-badge" data-letter="M"></span> __Reuse Enabled__
+
+    {% include-markdown "objective/enable-reuse.md"
+    start="<!--summary-start-->" end="<!--summary-end-->" %}
+    [:octicons-arrow-right-24: Learn more](../objective/enable-reuse.md)
+
+</div>
+
+[^copyright]: [Conveyor belt vector created by upklyak - www.freepik.com](https://www.freepik.com/vectors/conveyor-belt)
+
+<!--objectives-index-end-->

--- a/tests/test_objectives_url.py
+++ b/tests/test_objectives_url.py
@@ -1,0 +1,116 @@
+import subprocess
+from html.parser import HTMLParser
+from pathlib import Path
+
+import pytest
+
+
+class AnchorParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.anchors: list[tuple[str, str, str]] = []
+        self._current_anchor: dict[str, str] | None = None
+        self._current_text: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag != "a":
+            return
+
+        self._current_anchor = {
+            key: value or "" for key, value in attrs if key in {"class", "href"}
+        }
+        self._current_text = []
+
+    def handle_data(self, data: str) -> None:
+        if self._current_anchor is not None:
+            self._current_text.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag != "a" or self._current_anchor is None:
+            return
+
+        text = " ".join("".join(self._current_text).split())
+        self.anchors.append(
+            (
+                self._current_anchor.get("href", ""),
+                self._current_anchor.get("class", ""),
+                text,
+            )
+        )
+        self._current_anchor = None
+        self._current_text = []
+
+
+@pytest.fixture(scope="module")
+def site_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    output_dir = tmp_path_factory.mktemp("mkdocs-site") / "site"
+    subprocess.run(
+        ["mkdocs", "build", "--strict", "--site-dir", str(output_dir)],
+        check=True,
+    )
+    return output_dir
+
+
+def test_top_navigation_objectives_tab_targets_plural_index(site_dir: Path) -> None:
+    parser = AnchorParser()
+    parser.feed((site_dir / "index.html").read_text(encoding="utf-8"))
+
+    objectives_tab_hrefs = [
+        href
+        for href, class_name, text in parser.anchors
+        if text == "Objectives" and "md-tabs__link" in class_name.split()
+    ]
+
+    assert objectives_tab_hrefs == ["objectives/"]
+
+
+def test_plural_objectives_url_is_the_cards_page(site_dir: Path) -> None:
+    objectives_index = site_dir / "objectives" / "index.html"
+
+    assert objectives_index.exists()
+
+    objectives_html = objectives_index.read_text(encoding="utf-8")
+
+    assert '<h1 id="objectives">' in objectives_html
+    assert "objective-badge" in objectives_html
+    assert "../objective/interoperability/" in objectives_html
+
+
+def test_plural_objectives_url_keeps_original_objective_sidebar(site_dir: Path) -> None:
+    objectives_html = (site_dir / "objectives" / "index.html").read_text(encoding="utf-8")
+
+    assert (
+        '<li class="md-nav__item md-nav__item--active md-nav__item--section md-nav__item--nested">'
+    ) in objectives_html
+    assert (
+        '<input class="md-nav__toggle md-toggle " type="checkbox" id="__nav_2" checked>'
+    ) in objectives_html
+    assert 'aria-expanded="true"' in objectives_html
+    assert '<a href="../objective/interoperability/" class="md-nav__link">' in (objectives_html)
+    assert '<a href="../objective/" class="md-nav__link">' not in objectives_html
+    assert "../objectives/interoperability/" not in objectives_html
+
+
+def test_existing_singular_objective_urls_stay_unchanged(site_dir: Path) -> None:
+    objective_index = site_dir / "objective" / "index.html"
+    objective_detail = site_dir / "objective" / "interoperability" / "index.html"
+
+    assert objective_index.exists()
+    assert objective_detail.exists()
+
+    objective_index_html = objective_index.read_text(encoding="utf-8")
+    objective_detail_html = objective_detail.read_text(encoding="utf-8")
+
+    assert "Redirecting..." not in objective_index_html
+    assert "Redirecting..." not in objective_detail_html
+    assert '<h1 id="objectives">' in objective_index_html
+    assert '<h1 id="interoperability-achieved">' in objective_detail_html
+
+
+def test_only_plural_objectives_index_is_added(site_dir: Path) -> None:
+    plural_paths = [
+        path.relative_to(site_dir / "objectives")
+        for path in (site_dir / "objectives").rglob("*.html")
+    ]
+
+    assert plural_paths == [Path("index.html")]


### PR DESCRIPTION
## What changed

- Added `docs/objectives/index.md` so `/objectives/` builds as the Objectives cards page.
- Kept all existing singular objective URLs intact, including `/objective/` and `/objective/*` detail pages.
- Adjusted the MkDocs navigation hook so the top navigator lands on `/objectives/` while the left Objective sidebar keeps the original singular detail links and does not duplicate the old index page.
- Added regression tests for the plural index URL, preserved singular URLs, sidebar behavior, and absence of plural detail pages.

## Root cause

The Objectives section was indexed by `docs/objective/index.md`, so MkDocs generated `/objective/` but not `/objectives/`. A naive plural rename changes all detail URLs, which is not the requested behavior. The fix adds only the plural index page and makes it the visible section index in navigation while leaving the singular objective tree as the canonical detail URL space.

## Validation

- `uv run --extra dev pytest tests/test_objectives_url.py` -> 5 passed
- `uv run --extra dev ruff check docs/main.py tests/test_objectives_url.py` -> passed
- `pnpm exec markdownlint docs/objectives/index.md --ignore node_modules --ignore .husky --ignore site` -> passed
- `uv run mkdocs build --strict --site-dir /tmp/ekg-method-build-final` -> passed
- Local route checks:
  - `/objectives/` -> 200
  - `/objective/` -> 200
  - `/objective/interoperability/` -> 200
  - `/objectives/interoperability/` -> 404
- Playwright verified the top-nav Objectives click lands on `/objectives/` and the sidebar matches the original A-M objective list.