### PR TITLE
[codex] Redesign method homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,110 +17,213 @@ hide:
   - toc
 ---
 
-<div class="ekgf-hero" markdown="1">
+<!-- markdownlint-disable MD013 MD033 MD041 -->
 
-# Use Case Tree Method
-
-Deliver strategic business value and agility through connected
-enterprise knowledge — one use case at a time.
-
-<div class="ekgf-hero-buttons">
-<a href="concept/use-case-tree/" class="md-button md-button--primary">Explore the Use Case Tree</a>
-<a href="https://catalog.ekgf.org/use-case/" class="md-button">Browse example use cases</a>
-</div>
-
-</div>
-
-## Built for Business Outcomes
-
-<div class="ekgf-card-grid">
-  <div class="ekgf-image-card" style="background-image: url('https://images.unsplash.com/photo-1517048676732-d65bc937f952?auto=format&fit=crop&w=600&q=80');">
-    <div class="ekgf-image-card-content">
-      <strong>Business-owned roadmap</strong>
-      <p>Align strategy → capabilities → delivery with one shared artifact.</p>
+<div class="method-home">
+  <section class="method-hero" aria-labelledby="method-home-title">
+    <div class="method-hero__copy">
+      <h1 id="method-home-title">Use Case Tree Method</h1>
+      <p>
+        Turn strategic EKG use cases into reusable, governed,
+        continuously tested semantic components.
+      </p>
+      <div class="method-actions">
+        <a href="concept/use-case-tree/" class="md-button md-button--primary">Explore the Use Case Tree</a>
+        <a href="objective/strategic-usecases/" class="md-button">See strategic use cases</a>
+      </div>
     </div>
-  </div>
-  <div class="ekgf-image-card" style="background-image: url('https://images.unsplash.com/photo-1581091226825-a6a2a5aee158?auto=format&fit=crop&w=600&q=80');">
-    <div class="ekgf-image-card-content">
-      <strong>Composable delivery</strong>
-      <p>Ship small, reusable building blocks instead of monolithic systems.</p>
+
+    <div class="method-hero__visual" aria-label="Use Case Tree Method flow">
+      <div class="method-flow">
+        <div class="method-flow__node method-flow__node--strategy">
+          <span>Strategic Use Case</span>
+          <strong>Client 360, Risk, Compliance</strong>
+        </div>
+        <div class="method-flow__node method-flow__node--tree">
+          <span>Use Case Tree</span>
+          <strong>Scope and sequence</strong>
+        </div>
+        <div class="method-flow__node method-flow__node--package">
+          <span>Semantic Packages</span>
+          <strong>Reusable business capabilities</strong>
+        </div>
+        <div class="method-flow__node method-flow__node--running">
+          <span>Running EKG</span>
+          <strong>Measured, governed, improved</strong>
+        </div>
+      </div>
+
+      <div class="method-package-grid" aria-label="Semantic package contents">
+        <span>Outcomes</span>
+        <span>Stories</span>
+        <span>Workflows</span>
+        <span>Data Products</span>
+        <span>Ontologies</span>
+        <span>Tests</span>
+      </div>
     </div>
-  </div>
-  <div class="ekgf-image-card" style="background-image: url('https://images.unsplash.com/photo-1554224155-6726b3ff858f?auto=format&fit=crop&w=600&q=80');">
-    <div class="ekgf-image-card-content">
-      <strong>Quality + compliance</strong>
-      <p>Make traceability, controls, and auditability part of the design.</p>
+  </section>
+
+  <section class="method-section method-capabilities" aria-labelledby="capabilities-title">
+    <h2 id="capabilities-title">What the method makes possible</h2>
+    <div class="method-card-grid method-card-grid--four">
+      <article class="method-card">
+        <span class="method-card__mark">K</span>
+        <h3>Lighthouse use cases</h3>
+        <p>
+          Pick the strategic use case that proves EKG value where
+          traditional stacks cannot realistically deliver.
+        </p>
+        <a href="objective/strategic-usecases/">Explore strategic use cases</a>
+      </article>
+
+      <article class="method-card">
+        <span class="method-card__mark">M</span>
+        <h3>Semantic package manager</h3>
+        <p>
+          Use the Use Case Tree to publish versioned, discoverable
+          packages of business capability.
+        </p>
+        <a href="objective/enable-reuse/">Understand reuse</a>
+      </article>
+
+      <article class="method-card">
+        <span class="method-card__mark">D</span>
+        <h3>Executable knowledge</h3>
+        <p>
+          Capture outcomes, stories, workflows, data products, and
+          ontologies as living enterprise knowledge.
+        </p>
+        <a href="objective/capture-knowledge/">Capture knowledge</a>
+      </article>
+
+      <article class="method-card">
+        <span class="method-card__mark">I</span>
+        <h3>Functional health</h3>
+        <p>
+          Turn requirements into continuously tested stories, so the
+          EKG knows whether it still works.
+        </p>
+        <a href="objective/increase-quality/">Increase quality</a>
+      </article>
     </div>
-  </div>
-  <div class="ekgf-image-card" style="background-image: url('https://images.unsplash.com/photo-1550751827-4bd374c3f58b?auto=format&fit=crop&w=600&q=80');">
-    <div class="ekgf-image-card-content">
-      <strong>Production-proven</strong>
-      <p>A method refined across real EKG use cases running in production.</p>
+  </section>
+
+  <section class="method-section method-journey" aria-labelledby="journey-title">
+    <h2 id="journey-title">Plan → Build → Run</h2>
+    <p>
+      The method turns strategy into running capabilities through one
+      business-owned lifecycle.
+    </p>
+
+    <div class="method-phase-grid">
+      <article class="method-phase method-phase--plan">
+        <div class="method-phase__header">
+          <span>01</span>
+          <h3>Plan</h3>
+        </div>
+        <p>
+          Shape vision, discover strategic use cases, assess readiness,
+          train stakeholders, and chart the roadmap.
+        </p>
+        <div class="method-chip-row">
+          <a href="process/plan/envision/">Envision</a>
+          <a href="process/plan/discover/">Discover</a>
+          <a href="process/plan/assess/">Assess</a>
+          <a href="process/plan/train/">Train</a>
+          <a href="process/plan/chart/">Chart</a>
+        </div>
+      </article>
+
+      <article class="method-phase method-phase--build">
+        <div class="method-phase__header">
+          <span>02</span>
+          <h3>Build</h3>
+        </div>
+        <p>
+          Translate business requirements into executable models, tests,
+          workflows, and reusable components.
+        </p>
+        <div class="method-chip-row">
+          <a href="process/build/allocate/">Allocate</a>
+          <a href="process/build/design/">Design</a>
+          <a href="process/build/implement/">Implement</a>
+          <a href="process/build/test/">Test</a>
+          <a href="process/build/verify/">Verify</a>
+          <a href="process/build/deliver/">Deliver</a>
+        </div>
+      </article>
+
+      <article class="method-phase method-phase--run">
+        <div class="method-phase__header">
+          <span>03</span>
+          <h3>Run</h3>
+        </div>
+        <p>
+          Operate the EKG platform, measure outcomes, monitor functional
+          health, and optimize over time.
+        </p>
+        <div class="method-chip-row">
+          <a href="process/run/deploy/">Deploy</a>
+          <a href="process/run/operate/">Operate</a>
+          <a href="process/run/measure/">Measure</a>
+          <a href="process/run/optimize/">Optimize</a>
+        </div>
+      </article>
     </div>
-  </div>
-</div>
+  </section>
 
-<div class="ekgf-highlight-section" markdown="1">
+  <section class="method-section method-audiences" aria-labelledby="audience-title">
+    <h2 id="audience-title">Choose the path that matches your role</h2>
+    <div class="method-card-grid method-card-grid--three">
+      <article class="method-path">
+        <h3>Business leaders</h3>
+        <p>
+          Start with strategy, lighthouse use cases, business outcomes,
+          and the roadmap to measurable value.
+        </p>
+        <a href="process/plan/envision/">Start with Envision</a>
+      </article>
 
-## What is the Use Case Tree Method?
+      <article class="method-path">
+        <h3>Product and change teams</h3>
+        <p>
+          Use the tree to manage scope, expectations, reuse
+          opportunities, stakeholders, and delivery sequence.
+        </p>
+        <a href="process/plan/discover/">Start with Discover</a>
+      </article>
 
-The **Use Case Tree Method** is a business-owned approach to turn
-strategy into reusable EKG components — without
-[boiling the ocean](objective/avoid-boiling-the-ocean.md).
+      <article class="method-path">
+        <h3>Data and technology teams</h3>
+        <p>
+          Connect concepts, ontologies, data products, stories,
+          workflows, and tests into executable models.
+        </p>
+        <a href="concept/use-case/">Start with Use Case</a>
+      </article>
+    </div>
+  </section>
 
-Strategic capabilities like
-_[Enterprise Risk Management](https://catalog.ekgf.org/use-case/risk-management/)_
-or _[Client 360](https://catalog.ekgf.org/use-case/client-360/)_ are
-broken down into smaller use cases that you can — and should — deliver
-first. Each use case is a [reusable](objective/enable-reuse.md)
-[building block](objective/modularity.md) (see
-["Modularity Managed"](objective/modularity.md)).
-
-### The Use Case Tree in one sentence
-
-The [Use Case Tree](concept/use-case-tree.md) is a high-level map of
-the capabilities your enterprise plans to build — broken down into use
-cases with dependencies, so you can deliver in the right order.
-
-- **Plan**: Long-term
-  [data strategy](objective/align-with-business-strategy.md) and
-  business capability plan.
-- **Scope**: High-level requirements overview and dependency model.
-- **Align**: One single artifact for business, data, and technology
-  specialists.
-
-</div>
-
-## Explore the Method
-
-<div class="grid cards" markdown>
-
-- :material-target: **Objectives**
-
-  Why the method works:
-  [interoperability](objective/interoperability.md),
-  [reuse](objective/enable-reuse.md),
-  [modularity](objective/modularity.md),
-  [quality](objective/increase-quality.md),
-  [alignment](objective/align-with-business-strategy.md), and more.
-
-  [:octicons-arrow-right-24: Explore the objectives](objective/index.md)
-
-- :material-lightbulb-outline: **Concepts**
-
-  The core building blocks: [use case](concept/use-case/index.md),
-  [outcome](concept/outcome/index.md),
-  [workflow](concept/workflow.md), [terms](concept/term/index.md), and
-  more.
-
-  [:octicons-arrow-right-24: Explore concepts](concept/use-case/index.md)
-
-- :material-cog-outline: **Process**
-
-  [Plan](process/plan/index.md), [build](process/build/index.md), and
-  [run](process/run/index.md) EKG components — from first use case to
-  scale.
-
-  [:octicons-arrow-right-24: Explore the process](process/index.md)
-
+  <section class="method-section method-explore" aria-labelledby="explore-title">
+    <h2 id="explore-title">Explore the method</h2>
+    <div class="method-link-grid">
+      <a class="method-link-tile" href="objectives/">
+        <span>Objectives</span>
+        <strong>Why the method works</strong>
+      </a>
+      <a class="method-link-tile" href="concept/use-case-tree/">
+        <span>Concepts</span>
+        <strong>The building blocks</strong>
+      </a>
+      <a class="method-link-tile" href="process/">
+        <span>Process</span>
+        <strong>The delivery lifecycle</strong>
+      </a>
+      <a class="method-link-tile" href="article/">
+        <span>Articles</span>
+        <strong>Architecture and adoption</strong>
+      </a>
+    </div>
+  </section>
 </div>

--- a/docs/stylesheets/home.css
+++ b/docs/stylesheets/home.css
@@ -1,0 +1,444 @@
+.method-home {
+  --method-blue: #3f51b5;
+  --method-blue-strong: #2f3f98;
+  --method-orange: #f7941d;
+  --method-ink: #202124;
+  --method-muted: #5f6368;
+  --method-line: rgba(32, 33, 36, 0.14);
+  --method-soft: #f6f7f9;
+  --method-soft-blue: #eef2ff;
+  --method-soft-orange: #fff3e3;
+  --method-green: #2c7a66;
+  --method-shadow: 0 16px 40px rgba(32, 33, 36, 0.08);
+
+  color: var(--method-ink);
+  width: 100%;
+  margin: -2.4rem 0 0;
+}
+
+[data-md-color-scheme="slate"] .method-home {
+  --method-ink: #f4f6fb;
+  --method-muted: #c4c8d4;
+  --method-line: rgba(244, 246, 251, 0.16);
+  --method-soft: #171b24;
+  --method-soft-blue: #172036;
+  --method-soft-orange: #2b2117;
+  --method-shadow: 0 16px 40px rgba(0, 0, 0, 0.32);
+}
+
+.method-home h1,
+.method-home h2,
+.method-home h3 {
+  color: var(--method-ink);
+  letter-spacing: 0;
+}
+
+.method-home h1 {
+  max-width: 8.5em;
+  margin: 0;
+  font-size: clamp(2.4rem, 5vw, 4.2rem);
+  line-height: 0.98;
+  font-weight: 400;
+}
+
+.method-home h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.55rem, 2.5vw, 2.15rem);
+  line-height: 1.12;
+  font-weight: 400;
+}
+
+.method-home h3 {
+  margin: 0;
+  font-size: 1.02rem;
+  line-height: 1.25;
+  font-weight: 700;
+}
+
+.method-home p {
+  color: var(--method-muted);
+}
+
+.method-hero {
+  display: grid;
+  grid-template-columns: minmax(18rem, 0.9fr) minmax(30rem, 1.35fr);
+  gap: clamp(2rem, 5vw, 4.5rem);
+  align-items: center;
+  padding: clamp(2rem, 6vw, 4.5rem) 0 clamp(2.25rem, 6vw, 4rem);
+}
+
+.method-hero__copy > p {
+  max-width: 34rem;
+  margin: 1.4rem 0 0;
+  font-size: clamp(1.05rem, 1.5vw, 1.28rem);
+  line-height: 1.55;
+}
+
+.method-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 1.8rem;
+}
+
+.method-actions .md-button {
+  min-width: 12.5rem;
+  border-radius: 0.18rem;
+  font-size: 0.82rem;
+  text-align: center;
+}
+
+.method-hero__visual {
+  padding: clamp(0.5rem, 2vw, 1rem) 0;
+}
+
+.method-flow {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.method-flow__node {
+  position: relative;
+  display: grid;
+  grid-template-rows: 5rem 3rem auto;
+  row-gap: 0.85rem;
+  justify-items: center;
+  min-height: 0;
+  padding: 0;
+  text-align: center;
+}
+
+.method-flow__node::before {
+  display: grid;
+  width: 5rem;
+  height: 5rem;
+  margin: 0 auto;
+  border: 1.5px solid var(--method-blue);
+  border-radius: 50%;
+  place-items: center;
+  background: var(--md-default-bg-color);
+  color: var(--method-blue);
+  font-size: 1rem;
+  font-weight: 800;
+  box-shadow: 0 10px 26px rgba(63, 81, 181, 0.08);
+}
+
+.method-flow__node:not(:last-child)::after {
+  content: "→";
+  position: absolute;
+  top: 2.35rem;
+  right: -1.3rem;
+  z-index: 2;
+  color: var(--method-orange);
+  font-size: 1.55rem;
+  font-weight: 700;
+  transform: translateY(-50%);
+}
+
+.method-flow__node--strategy {
+  color: var(--method-orange);
+}
+
+.method-flow__node--strategy::before {
+  content: "01";
+  border-color: var(--method-orange);
+  color: var(--method-orange);
+  background: var(--method-soft-orange);
+}
+
+.method-flow__node--tree::before {
+  content: "02";
+}
+
+.method-flow__node--package::before {
+  content: "03";
+  border-color: var(--method-green);
+  color: var(--method-green);
+  background: rgba(44, 122, 102, 0.08);
+}
+
+.method-flow__node--running {
+  color: var(--method-green);
+}
+
+.method-flow__node--running::before {
+  content: "04";
+  border-color: var(--method-green);
+  color: var(--method-green);
+  background: rgba(44, 122, 102, 0.08);
+}
+
+.method-flow__node span,
+.method-phase__header span,
+.method-link-tile span {
+  display: block;
+  color: var(--method-blue);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.method-package-grid span {
+  display: block;
+  color: var(--method-blue);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.method-flow__node span {
+  display: flex;
+  align-items: start;
+  justify-content: center;
+  min-height: 3rem;
+  max-width: 9.5rem;
+  font-size: 0.9rem;
+  letter-spacing: 0;
+  line-height: 1.25;
+  text-transform: none;
+}
+
+.method-flow__node strong {
+  display: block;
+  max-width: 8.5rem;
+  margin: 0 auto;
+  color: var(--method-muted);
+  font-size: 0.76rem;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.method-package-grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.45rem;
+  margin-top: 1.8rem;
+  border: 1px solid var(--method-line);
+  border-radius: 0.45rem;
+  background: var(--md-default-bg-color);
+  padding: 0.75rem;
+  box-shadow: var(--method-shadow);
+}
+
+.method-package-grid span {
+  display: flex;
+  min-height: 2.95rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--method-line);
+  border-radius: 999px;
+  background: var(--method-soft);
+  padding: 0.38rem 0.18rem;
+  text-align: center;
+  white-space: nowrap;
+  overflow-wrap: normal;
+  word-break: keep-all;
+}
+
+.method-section {
+  padding: clamp(2.25rem, 6vw, 4.25rem) 0;
+  border-top: 1px solid var(--method-line);
+}
+
+.method-section > p {
+  max-width: 46rem;
+  margin-top: -0.35rem;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.method-card-grid {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.4rem;
+}
+
+.method-card-grid--four {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.method-card-grid--three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.method-card,
+.method-path,
+.method-phase,
+.method-link-tile {
+  border: 1px solid var(--method-line);
+  border-radius: 0.45rem;
+  background: var(--md-default-bg-color);
+}
+
+.method-card {
+  min-height: 15.5rem;
+  padding: 1.2rem;
+}
+
+.method-card__mark {
+  display: inline-grid;
+  width: 2.55rem;
+  height: 2.55rem;
+  margin-bottom: 1.1rem;
+  border-radius: 50%;
+  place-items: center;
+  background: var(--method-soft-blue);
+  color: var(--method-blue);
+  font-weight: 800;
+}
+
+.method-card:nth-child(1) .method-card__mark {
+  background: var(--method-soft-orange);
+  color: var(--method-orange);
+}
+
+.method-card p,
+.method-path p,
+.method-phase p {
+  margin: 0.75rem 0 1rem;
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.method-card a,
+.method-path a {
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.method-phase-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.method-phase {
+  padding: 1.2rem;
+  background: var(--method-soft);
+}
+
+.method-phase__header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.65rem;
+}
+
+.method-phase__header span {
+  color: var(--method-orange);
+}
+
+.method-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1.05rem;
+}
+
+.method-chip-row a {
+  border: 1px solid var(--method-line);
+  border-radius: 999px;
+  background: var(--md-default-bg-color);
+  padding: 0.32rem 0.62rem;
+  color: var(--method-ink);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.method-path {
+  padding: 1.25rem;
+  border-left: 0.28rem solid var(--method-blue);
+}
+
+.method-path:nth-child(1) {
+  border-left-color: var(--method-orange);
+}
+
+.method-path:nth-child(3) {
+  border-left-color: var(--method-green);
+}
+
+.method-link-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 1.4rem;
+}
+
+.method-link-tile {
+  display: block;
+  min-height: 7.5rem;
+  padding: 1.1rem;
+  color: inherit;
+}
+
+.method-link-tile strong {
+  display: block;
+  margin-top: 1rem;
+  color: var(--method-ink);
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+.method-link-tile:hover {
+  border-color: rgba(63, 81, 181, 0.55);
+  box-shadow: var(--method-shadow);
+}
+
+@media (max-width: 1100px) {
+  .method-hero,
+  .method-phase-grid,
+  .method-card-grid--three {
+    grid-template-columns: 1fr;
+  }
+
+  .method-card-grid--four,
+  .method-link-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .method-home h1 {
+    max-width: 7em;
+    font-size: 2.65rem;
+  }
+
+  .method-hero {
+    padding-top: 1.5rem;
+  }
+
+  .method-actions .md-button {
+    width: 100%;
+  }
+
+  .method-package-grid,
+  .method-card-grid--four,
+  .method-link-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .method-flow {
+    grid-template-columns: 1fr;
+  }
+
+  .method-flow__arrow {
+    transform: rotate(90deg);
+    justify-self: center;
+  }
+
+  .method-flow__node:not(:last-child)::after {
+    top: auto;
+    right: 50%;
+    bottom: -1.4rem;
+    transform: translateX(50%) rotate(90deg);
+  }
+
+  .method-flow__node {
+    min-height: auto;
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,8 @@ extra_javascript:
   - javascripts/mermaid.js
   - javascripts/darkable-objects.js
   - javascripts/objective-badges.js
+extra_css:
+  - stylesheets/home.css
 
 hooks:
   - docs/main.py

--- a/tests/test_homepage_redesign.py
+++ b/tests/test_homepage_redesign.py
@@ -1,0 +1,186 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import sync_playwright
+
+
+@pytest.fixture(scope="module")
+def site_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    output_dir = tmp_path_factory.mktemp("mkdocs-homepage") / "site"
+    subprocess.run(
+        ["mkdocs", "build", "--strict", "--site-dir", str(output_dir)],
+        check=True,
+    )
+    return output_dir
+
+
+def test_homepage_uses_method_specific_redesign(site_dir: Path) -> None:
+    html = (site_dir / "index.html").read_text(encoding="utf-8")
+
+    assert "method-home" in html
+    assert "Turn strategic EKG use cases into reusable" in html
+    assert "Strategic Use Case" in html
+    assert "Semantic Packages" in html
+    assert "Running EKG" in html
+
+
+def test_homepage_replaces_stock_photo_outcome_cards(site_dir: Path) -> None:
+    html = (site_dir / "index.html").read_text(encoding="utf-8")
+
+    assert "Built for Business Outcomes" not in html
+    assert "ekgf-image-card" not in html
+    assert "background-image:" not in html
+
+    for heading in [
+        "Lighthouse use cases",
+        "Semantic package manager",
+        "Executable knowledge",
+        "Functional health",
+    ]:
+        assert heading in html
+
+
+def test_homepage_exposes_plan_build_run_journey(site_dir: Path) -> None:
+    html = (site_dir / "index.html").read_text(encoding="utf-8")
+
+    assert "Plan → Build → Run" in html
+
+    for step in [
+        "Envision",
+        "Discover",
+        "Assess",
+        "Train",
+        "Chart",
+        "Allocate",
+        "Design",
+        "Implement",
+        "Test",
+        "Verify",
+        "Deliver",
+        "Deploy",
+        "Operate",
+        "Measure",
+        "Optimize",
+    ]:
+        assert step in html
+
+
+def test_homepage_left_edge_aligns_with_header_logo_word(site_dir: Path) -> None:
+    url = (site_dir / "index.html").resolve().as_uri()
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        page = browser.new_page(
+            viewport={"width": 1862, "height": 1280},
+            device_scale_factor=1,
+        )
+        page.goto(url, wait_until="load")
+        page.wait_for_selector(".method-home")
+
+        logo_word = page.locator(".md-header__button.md-logo .ekgf-logo-text").bounding_box()
+        homepage = page.locator(".method-home").bounding_box()
+        browser.close()
+
+    assert logo_word is not None
+    assert homepage is not None
+    assert abs(homepage["x"] - logo_word["x"]) <= 8
+
+
+def test_homepage_uses_full_article_width(site_dir: Path) -> None:
+    url = (site_dir / "index.html").resolve().as_uri()
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        page = browser.new_page(
+            viewport={"width": 1632, "height": 1536},
+            device_scale_factor=1,
+        )
+        page.goto(url, wait_until="load")
+        page.wait_for_selector(".method-home")
+
+        article = page.locator(".md-content__inner").bounding_box()
+        homepage = page.locator(".method-home").bounding_box()
+        first_section = page.locator(".method-capabilities").bounding_box()
+        browser.close()
+
+    assert article is not None
+    assert homepage is not None
+    assert first_section is not None
+    article_right = article["x"] + article["width"]
+    homepage_right = homepage["x"] + homepage["width"]
+    first_section_right = first_section["x"] + first_section["width"]
+    assert abs(homepage_right - article_right) <= 8
+    assert abs(first_section_right - article_right) <= 8
+
+
+def test_homepage_diagram_package_labels_fit_without_word_splitting(
+    site_dir: Path,
+) -> None:
+    url = (site_dir / "index.html").resolve().as_uri()
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        page = browser.new_page(
+            viewport={"width": 1862, "height": 1280},
+            device_scale_factor=1,
+        )
+        page.goto(url, wait_until="load")
+        page.wait_for_selector(".method-package-grid")
+
+        package_grid = page.locator(".method-package-grid").evaluate(
+            """
+            (element) => ({
+              overflow: element.scrollWidth - element.clientWidth,
+            })
+            """
+        )
+        labels = page.locator(".method-package-grid span").evaluate_all(
+            """
+            (elements) => elements.map((element) => {
+              const range = document.createRange();
+              range.selectNodeContents(element);
+              const lines = Array.from(range.getClientRects())
+                .filter((rect) => rect.width > 1 && rect.height > 1);
+              range.detach();
+
+              return {
+                text: element.textContent.trim(),
+                lineCount: lines.length,
+                overflow: element.scrollWidth - element.clientWidth,
+              };
+            })
+            """
+        )
+        browser.close()
+
+    assert package_grid["overflow"] <= 1
+    assert labels
+    for label in labels:
+        assert label["overflow"] <= 1, label
+        assert label["lineCount"] == 1, label
+
+
+def test_homepage_diagram_secondary_stage_labels_align_horizontally(
+    site_dir: Path,
+) -> None:
+    url = (site_dir / "index.html").resolve().as_uri()
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        page = browser.new_page(
+            viewport={"width": 1862, "height": 1280},
+            device_scale_factor=1,
+        )
+        page.goto(url, wait_until="load")
+        page.wait_for_selector(".method-flow")
+
+        stage_label_tops = page.locator(".method-flow__node strong").evaluate_all(
+            """
+            (elements) => elements.map((element) => element.getBoundingClientRect().top)
+            """
+        )
+        browser.close()
+
+    assert len(stage_label_tops) == 4
+    assert max(stage_label_tops) - min(stage_label_tops) <= 2


### PR DESCRIPTION
## Summary

- Redesigns the method homepage with a purpose-built hero, method flow diagram, capability cards, lifecycle section, role paths, and method links.
- Replaces the previous filtered stock-photo card section and the weak Explore the Method block with scoped homepage markup and CSS.
- Keeps the shared header, navigator, and footer untouched.

## Root Cause

The existing homepage leaned on generic image cards and default MkDocs card patterns, which made the page feel visually flat and inconsistent with the method content. During QA, the homepage-specific container and diagram styles also introduced layout regressions: content right edges did not align with the article rail, diagram chip labels wrapped inside ovals, and secondary diagram captions were not horizontally aligned.

## Changes

- Adds scoped `docs/stylesheets/home.css` styles under `.method-home`.
- Rebuilds `docs/index.md` around the Use Case Tree Method narrative and internal links.
- Registers the homepage stylesheet in `mkdocs.yml`.
- Adds rendered MkDocs/Playwright regression tests covering the homepage redesign, diagram label fit, left alignment with the header logo word, and full article-width alignment.

## Validation

- `uv run --extra dev pytest tests/test_homepage_redesign.py tests/test_objectives_url.py` → 12 passed
- `uv run --extra dev ruff check tests/test_homepage_redesign.py tests/test_objectives_url.py docs/main.py` → passed
- `uv run --extra dev ruff format --check tests/test_homepage_redesign.py tests/test_objectives_url.py docs/main.py` → passed
- `pnpm exec markdownlint docs/index.md docs/objectives/index.md --ignore node_modules --ignore .husky --ignore site` → passed
- `uv run mkdocs build --strict --site-dir /tmp/ekg-method-home-build-width-final` → passed, with the existing MkDocs 2.0 warning

## Rendered QA

- Desktop and mobile screenshots were checked with Playwright.
- CTA interaction verified: `Explore the Use Case Tree` navigates to `/concept/use-case-tree/`.
- Diagram metrics verified: package chip overflow `0`, all chip labels render on one line, secondary stage label vertical delta `0`.
- Width metrics verified: article, hero, first section, and card grid share the same right edge.