### PR TITLE
docs(concept): document concept manifestations

### DIFF
--- a/docs/concept/concept/concept-vocabulary.md
+++ b/docs/concept/concept/concept-vocabulary.md
@@ -33,49 +33,53 @@ domain, enabling reuse and consistency across use cases_
     A **Concept Vocabulary** is a collection of related
     [Concepts](index.md) that share a common context or domain. Think
     of it as a dictionary or glossary specific to a particular area of
-    your business---it groups together all the concepts and their terms
-    that make sense to use together.
+    your business. It groups together concepts and their
+    manifestations that make sense to use together.
 
     Just as you might have a "Finance Vocabulary" or a "Product
     Management Vocabulary" in your organization, the Use Case Tree
     Method organizes concepts into vocabularies to keep things clear
     and reusable.
 
-    ## How Concepts Work with Terms
+    ## How concepts work with manifestations
 
     An important characteristic of our Concept Vocabularies is how
-    concepts relate to the actual words people use:
+    concepts relate to the actual words and technical forms people and
+    systems use:
 
     - A **Concept** in our model is essentially just a unique
       identifier (a random UUID) that represents an idea or thing in
       your domain
-    - This concept can have **multiple Terms** associated with it---the
-      actual words or phrases people use to refer to that concept
+    - This concept can have **multiple manifestations** associated
+      with it, such as business words, abbreviations, API parameters,
+      query variables, ontology classes, shapes, and source
+      occurrences
     - This is a **one-to-many relationship**: one concept, potentially
-      many terms
+      many manifestations
 
-    ### Why Multiple Terms?
+    ### Why multiple manifestations?
 
     In a given context, people often use different words for the same
-    thing:
+    thing, and systems often use different identifiers for it:
 
     **Example: Hospital Context**
 
     > In a hospital use case, the concept of "a person receiving care"
-    > might have multiple terms:
+    > might have multiple manifestations:
     >
     > - "Patient" — medical staff terminology
     > - "Client" — administrative perspective
     > - "Customer" — billing department
     > - "Visitor" — reception desk
     >
-    > All these terms refer to the same underlying concept in this
-    > hospital context, so they're grouped under one Concept identifier.
+    > All these manifestations refer to the same underlying Concept in
+    > this hospital context, so they are grouped under one Concept
+    > identifier.
 
     ### Context Matters
 
-    The same terms might mean completely different things in other
-    contexts:
+    The same manifestation value might mean completely different things
+    in other contexts:
 
     - "Patient" in a hospital means something different than "patient"
       in a legal context (someone waiting)
@@ -83,15 +87,15 @@ domain, enabling reuse and consistency across use cases_
     - Each use case defines its own concepts that make sense in its
       context
 
-    The Concept (the UUID) ties together all the terms that mean the
-    same thing **in your specific use case context**.
+    The Concept (the UUID) ties together all the manifestations that
+    mean the same thing **in your specific use case context**.
 
-    !!! note "Terms are reusable, Concepts are context-specific"
+    !!! note "Manifestations can repeat, Concepts are contextual"
 
-        The **terms** themselves (like "patient", "client") can be
-        reused across many vocabularies and use cases. But the
-        **concept** that groups those terms together is specific to the
-        use case's context and meaning.
+        The **manifestation values** themselves, such as "patient",
+        "client", `?patient`, or `patient_id`, can appear in many
+        vocabularies and systems. The **Concept** that groups them
+        together is specific to the use case's context and meaning.
 
     ## Why Use Concept Vocabularies?
 
@@ -103,8 +107,8 @@ domain, enabling reuse and consistency across use cases_
     2. **Reuse** — Allows multiple use cases to share the same
        vocabulary without duplicating concepts
 
-    3. **Consistency** — Ensures that the same terms mean the same
-       things across different parts of the organization
+    3. **Consistency** — Ensures that the same manifestation values
+       can be interpreted in the right context
 
     4. **Ownership** — Clarifies who is responsible for defining and
        maintaining concepts in each domain
@@ -337,14 +341,15 @@ domain, enabling reuse and consistency across use cases_
     A Story may reference Concepts from multiple
     vocabularies.
 
-    ## Relationship to Terms
+    ## Relationship to manifestations
 
-    [Terms](../term/index.md) are part of concepts, which are part of
-    vocabularies:
+    [Concept Manifestations](../term/index.md) are attached to
+    concepts, which are part of vocabularies:
 
     - A Concept Vocabulary contains multiple Concepts
-    - Each Concept has one or more Terms
-    - Terms provide the actual labels and names used in different
+    - Each Concept can have zero or more manifestations
+    - Manifestations provide the labels, names, variables, schema
+      resources, shapes, and source occurrences used in different
       contexts
 
 === "Ontology"
@@ -380,12 +385,13 @@ domain, enabling reuse and consistency across use cases_
 
     - A **Concept** is essentially just a **universally unique
       identifier** (UUID)
-    - The Concept identifier represents the abstract idea or thing
-    - The Concept has a **one-to-many relationship** with **Terms**
-    - Terms are the actual manifestations---the words and phrases
-      people use
-    - A Concept can have multiple Terms, each representing different
-      ways people refer to the same thing in a given context
+    - The Concept identifier represents the local linking pin
+    - The Concept has a **one-to-many relationship** with
+      **Concept Manifestations**
+    - Manifestations are the observable forms: words, phrases, code
+      identifiers, schema resources, shapes, and source occurrences
+    - A Concept can have multiple manifestations, each representing a
+      different way the same meaning appears in a given context
 
     **Why this matters:**
 
@@ -394,32 +400,31 @@ domain, enabling reuse and consistency across use cases_
 
     ```
     Concept: urn:uuid:a1b2c3d4-... (hospital visitor concept)
-    ├── Term: "Patient" (medical staff usage)
-    ├── Term: "Client" (administrative usage)
-    ├── Term: "Customer" (billing department usage)
-    └── Term: "Visitor" (reception desk usage)
+    ├── BusinessTerm: "Patient" (medical staff usage)
+    ├── BusinessTerm: "Client" (administrative usage)
+    ├── URIParameterManifestation: "patient-id"
+    └── OWLClassManifestation: hospital:Patient
     ```
 
-    All these terms refer to the same underlying concept **in this
-    hospital use case's context**. In other contexts, these same terms
-    might mean completely different things and wouldn't be grouped
+    All these manifestations refer to the same underlying Concept
+    **in this hospital use case's context**. In other contexts, these
+    same values might mean different things and would not be grouped
     together.
 
     **Key insight:**
 
-    - **Concepts** (the UUID identifier) are **context-specific** to
-      the use case
-    - **Terms** (the actual words) are **reusable** across many
-      contexts
-    - The Concept binds together all the terms that mean the same thing
-      in your specific use case context
+    - **Concepts** are context-specific linking pins
+    - **Manifestation values** can recur across many contexts
+    - The Concept binds together all manifestations that mean the same
+      thing in your specific use case context
 
     This separation allows:
 
-    - Different use cases to use the same terms with different meanings
-    - One use case to group multiple terms under one concept
-    - Clear traceability of which terms are considered equivalent in
-      which contexts
+    - Different use cases to use the same values with different
+      meanings
+    - One use case to group multiple manifestations under one Concept
+    - Clear traceability of which manifestations are considered
+      equivalent in which contexts
 
     ### Concept Vocabulary
 
@@ -511,5 +516,5 @@ domain, enabling reuse and consistency across use cases_
   stories use concepts
 - [Use Case](../use-case/index.md) — How use cases relate to
   vocabularies
-- [Term](../term/index.md) — Components of concepts within
-  vocabularies
+- [Concept Manifestation](../term/index.md) — Observable forms of
+  concepts within vocabularies

--- a/docs/concept/concept/index.md
+++ b/docs/concept/concept/index.md
@@ -1,9 +1,8 @@
 ---
 description: >-
-  A domain term or idea that links business language to semantic
-  models, enabling the Enterprise Knowledge Graph to understand and
-  reason about business concepts. Learn how concepts bridge business
-  and technical domains in the Use Case Tree Method.
+  A thin linking pin for a context-specific meaning, connected to
+  business terms, technical manifestations, ontology resources,
+  shapes, taxonomies, code identifiers, and source occurrences.
 keywords:
   - concept
   - domain concept
@@ -18,9 +17,9 @@ schema_type: "Article"
 
 <!--summary-start-->
 
-_A domain term or idea that links business language to semantic
-models, enabling the Enterprise Knowledge Graph to understand and
-reason about business concepts_
+_A thin linking pin for a context-specific meaning, connected to
+business terms, technical manifestations, models, code, data, and
+source occurrences_
 
 <!--summary-end-->
 
@@ -29,14 +28,18 @@ reason about business concepts_
     ## What Is a Concept?
 
     For every given [Use Case](../use-case/index.md), we want to start with
-    capturing the concepts and terms that the user or "the business"
-    uses or wants to use.
+    capturing the concepts and manifestations that the user or
+    "the business" uses or wants to use.
 
-    A **Concept** is a way to represent a business idea or term in a
-    way that both humans and machines can understand.
-    It serves as a bridge between the language your organization uses
-    and the formal semantic models (ontologies) that enable the
-    Enterprise Knowledge Graph to reason about your business.
+    A **Concept** is a context-specific linking pin for a meaning.
+    It is deliberately small: the Concept itself does not need to
+    carry every label, ontology class, shape, data field, or code
+    identifier.
+
+    Instead, it links to
+    [Concept Manifestations](../term/index.md): business names,
+    synonyms, abbreviations, API parameters, query variables,
+    ontology terms, shapes, taxonomy entries, and source occurrences.
 
     ## Why Concepts Matter
 
@@ -44,8 +47,9 @@ reason about business concepts_
 
     - **Business language is preserved** — We capture terms as the
       business uses them, not as some external standard defines them
-    - **Semantic meaning is enabled** — Concepts link to ontologies
-      that give them machine-readable meaning
+    - **Semantic meaning is enabled** — Concepts link to technical
+      manifestations that point at ontologies, shapes, taxonomies,
+      code, and data
     - **Consistency is maintained** — The same concept can be reused
       across multiple use cases
     - **Interoperability is achieved** — Concepts can map to
@@ -63,9 +67,9 @@ reason about business concepts_
     **[Concept Vocabularies](concept-vocabulary.md)**---collections of
     related concepts that share a common context or domain.
 
-    Most concepts and their terms will be pre-defined in all kinds of
-    vocabularies, but for brand-new use cases in a new domain,
-    concepts and their terms will have to be created.
+    Most concepts and manifestations will be pre-defined in all kinds
+    of vocabularies. For brand-new use cases in a new domain,
+    concepts and their manifestations may have to be created.
 
     Each Use Case can have its own vocabulary of concepts, but it can
     also inherit or borrow concepts from higher-level or related use
@@ -82,22 +86,23 @@ reason about business concepts_
 
     - **Adjust concepts** — Better reflect the reality of the domain
     - **Map to ontologies** — Link concepts to more appropriate
-      terms in specific ontologies or vocabularies to ensure
-      consistency and interoperability across the enterprise
+      ontology terms, shapes, taxonomies, or other technical
+      manifestations to ensure consistency and interoperability
+      across the enterprise
 
     In either case, the important thing is to ensure that the
-    captured concepts and terms accurately reflect the reality of the
-    domain and the needs of the stakeholders.
+    captured concepts and manifestations accurately reflect the
+    reality of the domain and the needs of the stakeholders.
 
 === "Data & Tech Audience"
 
     ## What Is a Concept in the Use Case Tree Method?
 
-    A **Concept** is the linking pin between local business language
-    and formal semantic models (ontologies).
-    It enables the EKG to understand business terminology while
-    maintaining connections to standardized vocabularies and enabling
-    automated reasoning.
+    A **Concept** is the linking pin between local business language,
+    technical implementation, and formal semantic models.
+    It stays deliberately thin. Business terms, technical identifiers,
+    ontology resources, SHACL shapes, taxonomy entries, and source
+    occurrences are modeled as Concept Manifestations.
 
     ## The Concept Lifecycle
 
@@ -117,21 +122,19 @@ reason about business concepts_
         The business owns its use cases and should recognize them
         throughout their lifecycle.
 
-    ### Mapping to Ontologies
+    ### Mapping to ontologies and shapes
 
     Later in the use case's lifecycle, once the problem is well
-    understood, the relevant ontologies can be mapped to the terms and
-    concepts captured earlier.
+    understood, the relevant ontologies, shapes, and taxonomies can be
+    mapped to manifestations of the concepts captured earlier.
     This allows for better integration of the use case with the
     overall EKG ecosystem.
 
     !!! note "Implementation Detail"
         The mapping to OWL ontologies or SHACL shapes is primarily a
         technical implementation detail that is local to the specific
-        use case. Different use cases may map to the same ontology in
-        completely different ways, reflecting their unique business
-        contexts and requirements. This flexibility ensures that
-        ontology mappings serve the use case rather than constraining it.
+        use case. The Concept links to an OWL or SHACL manifestation;
+        the manifestation points at the ontology resource or shape.
 
     ### Refinement and Evolution
 
@@ -141,27 +144,30 @@ reason about business concepts_
     - **Adjust captured concepts** — Better reflect the reality of
       the domain
     - **Map to appropriate ontologies** — Link to more appropriate
-      terms in specific ontologies or vocabularies to ensure
-      consistency and interoperability across the enterprise
+      ontology resources, shapes, taxonomies, or other technical
+      manifestations to ensure consistency and interoperability
+      across the enterprise
 
-    ## Concept Types
+    ## Manifestation types
 
-    Concepts can represent different types of semantic elements:
+    Concepts do not need a class/property/shape subtype hierarchy.
+    Their manifestations carry that detail:
 
-    - **Class Concepts** — Represent types or categories (e.g.,
-      "Person", "Account", "Transaction")
-    - **Property Concepts** — Represent relationships or attributes
-      (e.g., "hasOwner", "isLocatedIn", "hasValue")
-    - **Shape Concepts** — Represent validation constraints or data
-      shapes
+    - **Business Terms** represent names, synonyms, and abbreviations.
+    - **Technical Manifestations** represent API parameters, code
+      identifiers, query variables, tables, and columns.
+    - **OWL Manifestations** represent classes, properties,
+      individuals, and axioms.
+    - **SHACL Manifestations** represent node shapes and property
+      shapes.
+    - **SKOS Manifestations** represent concepts and concept schemes.
 
     ## Concepts as Linking Pins
 
     Concepts are the linking pin in many ways.
-    They link "business terms" and "technical terms" as they are
-    used in the context of the given use case, by the business and
-    by various programs, apps, and systems, in all their variations
-    and manifestations.
+    They link Business Terms and Technical Manifestations as they are
+    used in the context of the given use case, by the business and by
+    programs, apps, systems, statements, ontologies, and data.
 
     !!! tip "Context-Specific Linking"
 
@@ -189,10 +195,9 @@ reason about business concepts_
       or `sh:minCount`)
 
     All these symbols, terms, axioms, and shapes are manifestations
-    of the same concept and linked to it.
-    Even the mapping to certain axioms in an OWL ontology or
-    certain shapes in a SHACL shape would be seen as "technical
-    terms" — just yet some other manifestations of a given concept.
+    of the same Concept and linked to it.
+    Mappings to OWL axioms or SHACL shapes are Technical
+    Manifestations, not direct properties of the Concept.
 
     This enables the EKG to understand that these different
     representations all refer to the same business concept, enabling
@@ -244,8 +249,9 @@ reason about business concepts_
       semantic definition and reasoning
     - **[Stories](../story/index.md)** — Stories reference domain concepts
       that need to be understood and modeled
-    - **[Ontologies](../ontology.md)** — Concepts link to ontology
-      classes, properties, and shapes
+    - **[Ontologies](../ontology.md)** — Concepts link through
+      manifestations to ontology classes, properties, axioms, and
+      shapes
 
 === "Ontology"
 
@@ -274,25 +280,27 @@ reason about business concepts_
         - Do **not** use the slug as a foreign key in the Knowledge Graph itself; use the real
           identifier for references.
 
-    - **Label Term (instead of a traditional label)**
-        - A Concept does not have a traditional label such as `skos:prefLabel` or `rdfs:label`.
-        - Instead, it has a **labelTerm** link to one of its **BusinessTerm** objects (a resource
-          in the Knowledge Graph).
-        - Learn more in [Term](../term/index.md).
+    - **Preferred Business Term**
+        - A Concept does not need a traditional label such as
+          `skos:prefLabel` or `rdfs:label`.
+        - Instead, it can link to a preferred **BusinessTerm**.
+        - Learn more in
+          [Concept Manifestation](../term/index.md).
 
     - **Definition**
-        - A Concept must have a business-focused definition explaining what it means in context.
+        - A Concept must have a business-focused definition explaining
+          what it means in context.
 
-    - **One or more Terms (required)**
-        - A Concept must have **one or more Terms** (`Term`), which can be either a
-          **BusinessTerm** or a **TechnicalTerm**.
-        - A Concept without a Term has no reason to exist.
-        - All Terms of a Concept **mean the same thing** in the context of that Concept.
-        - Terms may include alternative spellings, abbreviations, synonyms, and technical
-          manifestations.
-        - Terms are **owned** by the Concept (part-of): when the Concept is deleted, its Term
-          objects are deleted as well.
-        - Learn more in [Term](../term/index.md).
+    - **Zero or more manifestations**
+        - A Concept can have zero or more
+          `ConceptManifestation` resources.
+        - Manifestations may include spellings, abbreviations,
+          synonyms, variables, columns, ontology resources, shapes,
+          taxonomy entries, and source occurrences.
+        - A Concept can start empty and become meaningful as
+          manifestations are discovered or curated.
+        - Learn more in
+          [Concept Manifestation](../term/index.md).
 
     - **Contained in a Concept Vocabulary**
         - A Concept is a member of a Concept Vocabulary (a “container” of Concepts).
@@ -301,12 +309,13 @@ reason about business concepts_
             - **own** a private vocabulary.
 
     - **Mapping to ontologies (optional)**
-        - A Concept can be mapped/aligned to terms in one or more ontologies (classes,
-          properties, shapes).
-        - Model this via mapping/alignment relationships so you can capture confidence, rationale,
-          and provenance.
+        - A Concept can link to OWL, SHACL, SKOS, SQL, and source
+          artifacts through Technical Manifestations.
+        - The manifestation carries the resource or literal value and
+          any provenance.
 
     - **Used by Stories and Workflows**
-        - Stories use Concepts as **input**, **output**, and **dependent** concepts.
-        - Workflows use Concepts through the Stories they orchestrate and the vocabulary of the
-          Use Case.
+        - Stories use Concepts as **input**, **output**, and
+          **dependent** concepts.
+        - Workflows use Concepts through the Stories they orchestrate
+          and the vocabulary of the Use Case.

--- a/docs/concept/data-product.md
+++ b/docs/concept/data-product.md
@@ -119,8 +119,8 @@ case's requirements_
     The choice of semantic data products to be used for a given use
     case should be made based on:
 
-    - **Semantic relevance** — Does the data product contain
-      concepts and terms that match the use case's vocabulary?
+    - **Semantic relevance** — Does the data product contain concepts
+      and manifestations that match the use case's vocabulary?
     - **Suitability** — Does the data product meet the use case's
       requirements?
     - **Quality** — Is the data product well-maintained and

--- a/docs/concept/term/.pages.yaml
+++ b/docs/concept/term/.pages.yaml
@@ -1,4 +1,4 @@
-title: Term
+title: Concept Manifestation
 nav:
   - index.md
   - business-term.md

--- a/docs/concept/term/business-term.md
+++ b/docs/concept/term/business-term.md
@@ -1,62 +1,81 @@
 ---
 description: >-
-  User-facing terminology used in conversations, documentation, UI,
-  and policies. Learn how Business Terms link to Concepts in the Use
-  Case Tree Method.
+  A human-facing Concept Manifestation used in conversations,
+  documentation, user interfaces, policies, glossaries, and
+  governance.
 keywords:
   - business term
-  - term
+  - concept manifestation
   - glossary
   - vocabulary
   - EKG method
 schema_type: "Article"
 ---
 
-# Business Term
+# Business term
 
 <!--summary-start-->
 
-_User-facing terminology used in conversations, documentation, UI, and
-policies_
+_A human-facing Concept Manifestation used in conversations,
+documentation, user interfaces, policies, and governance_
 
 <!--summary-end-->
 
 === "Business & Management Audience"
 
-    ## What is a Business Term?
-    A **Business Term** is a human-readable label for a [Concept](../concept/index.md). It represents how business users speak about a specific meaning within a given context.
+    ## What is a business term?
 
-    By linking multiple Business Terms (synonyms) to a single Concept, the Enterprise Knowledge Graph ensures that everyone is talking about the same underlying meaning even if they use different words.
+    A **Business Term** is a human-facing
+    [Concept Manifestation](index.md). It is how people speak about a
+    Concept in a specific context.
 
-    ## Key Characteristics
-    - **User-facing**: Used in documentation, policies, and user interfaces.
-    - **Context-specific**: A term might mean different things in different contexts, but it always links to a specific Concept that defines its meaning in *this* context.
-    - **Synonym support**: Multiple business terms can manifest the same Concept.
+    Multiple Business Terms can point to one Concept when they mean the
+    same thing in that context. For example, "Customer",
+    "Counterparty", and "Client" may all be valid Business Terms for
+    one Concept in one use case, while meaning different things in
+    another use case.
+
+    ## Key characteristics
+
+    - **User-facing**: used in documentation, policies, UI, and
+      conversation.
+    - **Context-specific**: a term may mean different things in
+      different contexts.
+    - **Governable**: business owners can decide whether two terms
+      really mean the same Concept.
+    - **Mergeable**: Concepts can be merged later when owners agree
+      that they mean the same thing.
 
     ## Examples
-    - “Customer”
-    - “Counterparty”
-    - “Risk Position”
+
+    - "Customer"
+    - "Counterparty"
+    - "Risk Position"
+    - "Beneficial Owner"
 
 === "Data & Tech Audience"
 
-    ## Business Terms as Concept Manifestations
-    From a technical perspective, a Business Term is a specific type of [Term](index.md) that provides the human-readable "face" of a Concept.
+    ## Business terms as manifestations
 
-    ## Lexical Variants
-    A single Business Term often has multiple forms for different communication contexts:
+    A Business Term is a specialization of
+    `concept:ConceptManifestation`.
+    It carries human-readable lexical forms such as:
 
-    - **Singular**: “Patient”
-    - **Plural**: “Patients”
-    - **Abbreviation**: “Pat.”
-    - **Short label**: “P”
+    - preferred label
+    - synonym
+    - abbreviation
+    - singular form
+    - plural form
+    - short UI label
 
-    These are variations of the **same Business Term object**. If two different words are used (e.g., “Patient” and “Client”), they should be modeled as two separate Business Term objects linking to the same Concept.
+    The Concept itself stays thin. The preferred display label is a
+    link from the Concept to a preferred Business Term.
 
 === "Ontology"
 
     --8<-- "fragment/uctm-diagram-business-term.md"
 
+    <span id="ontology"></span>
     ## Facts
 
     !!! info "About these facts"
@@ -65,10 +84,15 @@ policies_
         minimal facts you can use to build your own ontology, schema,
         or graph model.
 
-    ### Business Term
-    - **Inherits from Term**: All facts required for a [Term](index.md#ontology) (UUID, lexical forms, ownership) apply here.
-    - **Term Kind**: Must be identified as a "Business Term".
-    - **Language**: Should include a natural language tag (e.g., `en`, `nl`).
+    ### BusinessTerm
 
-    ### Relationship to Concept
-    - **Owned by Concept**: A Business Term is a part-of a Concept. If the Concept is deleted, the Business Term is deleted.
+    - **Subclass of ConceptManifestation**
+        - All manifestation facts apply here.
+    - **Language**
+        - A natural language tag should be used when the form is
+          language-specific.
+    - **Lexical form**
+        - Use a label or value for the exact business-facing text.
+    - **Preferred role**
+        - A Concept can mark one Business Term as its preferred
+          business-facing manifestation in a given context.

--- a/docs/concept/term/index.md
+++ b/docs/concept/term/index.md
@@ -1,101 +1,103 @@
 ---
 description: >-
-  A manifestation of a Concept: a business-facing or technical term
-  (e.g., synonyms, abbreviations, variable names) that all mean the
-  same thing in the Concept's context. Learn how Terms work in the Use
-  Case Tree Method.
+  A concrete manifestation of a Concept: a business-facing term, code
+  identifier, query variable, schema resource, shape, or source
+  occurrence that shows where the Concept appears.
 keywords:
-  - term
+  - concept manifestation
+  - manifestation
   - business term
-  - technical term
+  - technical manifestation
   - concept term
   - EKG method
   - enterprise knowledge graph
 schema_type: "Article"
 ---
 
-# Term
+# Concept manifestation
 
 <!--summary-start-->
 
-_A manifestation of a Concept: the words (business-facing and
-technical) used to refer to the same underlying meaning_
+_A concrete place where a Concept shows up in language, code, data,
+metadata, schemas, or source artifacts_
 
 <!--summary-end-->
 
 === "Business & Management Audience"
 
-    ## What Is a Term?
+    ## What is a concept manifestation?
 
-    A **Term** is a word or phrase people use to refer to a [Concept](../concept/index.md) in a given
-    context.
-    Concepts are about **meaning**; Terms are about **how that meaning shows up** in language.
+    A **Concept Manifestation** is a visible form of a
+    [Concept](../concept/index.md) in a given context.
+    Concepts are about meaning. Manifestations are how that meaning
+    shows up.
 
-    A Concept can have multiple Terms (synonyms, abbreviations, variations), but they all refer
-    to the **same meaning** in the context of that Concept.
+    A Concept can have many manifestations:
 
-    ## Business Terms vs Technical Terms
+    - business names, synonyms, and abbreviations
+    - labels used in documentation or user interfaces
+    - report column names and spreadsheet headers
+    - API field names and parameter names
+    - ontology terms and validation shapes
 
-    Terms come in two broad categories:
+    The Concept remains the linking pin. The manifestations give the
+    Concept its observable forms.
 
-    - **[Business Terms](business-term.md)** — user-facing terminology used in conversations, documentation, UI, and
-      policies (e.g., “Customer”, “Counterparty”, “Risk Position”)
-    - **[Technical Terms](technical-term.md)** — manifestations in code and data (e.g., variable names, column names,
-      API parameters, query bindings)
+    ## Business terms and technical manifestations
 
-    Treat both as Terms, because both are used by people, and both need to be linked back to the
-    Concept so everyone stays aligned.
+    Manifestations come in two broad groups:
+
+    - **[Business Terms](business-term.md)** are human-facing
+      manifestations used in conversations, documentation, UI, and
+      policies.
+    - **[Technical Manifestations](technical-term.md)** are
+      machine-facing manifestations in code, queries, schemas,
+      ontologies, shapes, APIs, and source repositories.
+
+    Treat both as manifestations because both need to be linked back
+    to the Concept.
 
 === "Data & Tech Audience"
 
-    ## Terms as Concept Manifestations
+    ## Manifestations as evidence
 
-    A Term is a **manifestation** of a Concept.
+    A manifestation is evidence that a Concept appears somewhere.
     It can be:
 
     - a preferred business phrase
-    - an abbreviation
-    - a synonym
-    - a technical symbol in code (e.g., `_customer`, `cust_id`, `?cust`, `/customers`)
+    - an abbreviation or synonym
+    - a JavaScript, Python, SQL, SPARQL, or Cypher identifier
+    - an API path parameter or query parameter
+    - an OWL class, OWL property, or OWL axiom
+    - a SHACL shape or property shape
+    - a SKOS concept or concept scheme
+    - a source occurrence in a repository
 
-    Terms allow the Knowledge Graph to connect human language and technical artifacts back to a
-    consistent semantic core (the Concept).
+    This lets the Knowledge Graph connect human language and technical
+    artifacts back to the same Concept without putting schema-specific
+    claims directly on the Concept.
 
-    ## Discovering Technical Terms in code and data
+    ## Discovering manifestations
 
-    Technical Terms can often be **discovered automatically** by scanning the organization’s
-    repositories and data artifacts:
-    Python/Java code, SQL, configuration, CSV column headers, API specs, and more.
+    Manifestations can be created manually, but many can be discovered
+    by scanning repositories and data artifacts:
 
-    Each detected manifestation becomes a **Technical Term** that links to:
+    - source code
+    - SQL, SPARQL, Cypher, and GQL statements
+    - RDF, OWL, SHACL, and SKOS files
+    - API specifications
+    - CSV files and database schemas
 
-    - the **Concept** it manifests, and optionally
-    - the **Business Term** it corresponds to in that context.
+    Each detected occurrence can point at the manifestation it
+    observed, including repository, file path, line, column, commit,
+    and language or format.
 
-    Example:
-    If you detect the CSV header `P`, you can link that Technical Term to the Concept and also to
-    the Business Term “Patient”.
+    ## Preferred manifestation
 
-    Technical Terms also include **semantic/validation artifacts** introduced later in the Use
-    Case lifecycle (especially during the Build phase), such as:
-
-    - OWL classes/properties/axioms in an ontology, and
-    - SHACL shapes and constraints.
-
-    In those cases, you link the Concept (and optionally a Business Term) to the ontology/shapes
-    term via a **special mapping relationship** (e.g. “representsClass”, “representsProperty”,
-    “constrainedByShape”), pointing at the ontology IRI.
-
-    Example:
-    If the Concept “patient” corresponds to the OWL class `hospital:Patient` in a Hospital
-    ontology, create a Technical Term representing that ontology term and link it with something
-    like **representsClass → `hospital:Patient`**.
-
-    ## Preferred Term
-
-    Concepts don’t need a traditional `rdfs:label` / `skos:prefLabel` label.
-    Instead, a Concept can point to a **preferred Term** (a Term object) that represents the
-    preferred expression in that context.
+    Concepts do not need to carry their own display labels. Instead,
+    a Concept can point at a preferred Business Term. Technical roles
+    can also have preferred manifestations, such as the preferred API
+    parameter or preferred SPARQL placeholder.
 
 === "Ontology"
 
@@ -110,59 +112,47 @@ technical) used to refer to the same underlying meaning_
         minimal facts you can use to build your own ontology, schema,
         or graph model.
 
-    ### Term
+    ### ConceptManifestation
 
     - **Opaque universally unique identifier**
-        - A Term should have an **opaque**, **universally unique** identifier.
-        - Prefer a random identifier such as **UUIDv4**, represented as a URI:
+        - A manifestation should have an opaque, universally unique
+          identifier.
+        - Prefer a random identifier such as UUIDv4, represented as
+          a URI:
           `urn:uuid:550e8400-e29b-41d4-a716-446655440000`
 
-    - **One or more forms (lexical variants)**
-        - A Term must have **one or more textual forms** (the actual strings).
-        - Business Terms often need multiple forms for different UI / communication contexts, for
-          example:
-            - **Singular**: “Patient”
-            - **Plural**: “Patients”
-            - **Abbreviation**: “Pat.”
-            - **Short label**: “P”
-        - These are variations of the **same Term** (think “sub-manifestations” of the Term).
-          They should not be mixed with the forms of a different Term.
+    - **Belongs to a Concept**
+        - A manifestation links to exactly one Concept in the local
+          context.
+        - A Concept can have zero or more manifestations.
+        - The same real-world token may appear as separate
+          manifestations when two Concepts intentionally do not mean
+          the same thing.
 
-        Example:
-        If “Patient” and “Client” are both used to mean the same thing in a given Use Case
-        context, model them as **two separate Business Term objects**, each with their own
-        lexical forms.
-        Both Terms link to the same Concept, and the Concept defines the shared meaning.
-
-    - **Term kind**
-        - A Term should indicate whether it is a **Business Term** or a **Technical Term**.
-
-    - **Owned by a Concept**
-        - Terms are **owned** by a Concept (part-of): when the Concept is deleted, its Term
-          objects are deleted as well.
-        - A Concept must have **one or more Terms**.
-        - All Terms for a Concept **mean the same thing** in that Concept’s context.
+    - **Manifestation kind**
+        - A manifestation should state its kind, such as
+          `BusinessTerm`, `TechnicalManifestation`,
+          `OWLClassManifestation`, `SHACLShapeManifestation`,
+          `SQLColumnManifestation`, or
+          `JavaScriptIdentifierManifestation`.
 
     ### Optional but useful facts
 
-    - **Language**: natural language tag for business terms (e.g., `en`, `nl`)
-    - **System / artifact**: where a technical term appears (e.g., codebase, dataset, API)
-    - **Term subtype**: for technical terms (e.g., `VariableName`, `ColumnName`, `ApiFieldName`,
-      `QueryBinding`)
-    - **Provenance**: who introduced the term, when, and why
+    - **Literal form**: exact string, label, slug, variable, or token.
+    - **Resource form**: RDF IRI for an OWL, SHACL, SKOS, SQL, or
+      other schema resource.
+    - **Language**: natural language tag for business terms.
+    - **System or artifact**: where the manifestation appears.
+    - **Provenance**: who introduced it, when, and why.
 
-    ### Optional facts for Technical Terms (recommended)
+    ### Optional source occurrence facts
 
-    When a Term is discovered in code/data, capture **where it came from**:
+    When a manifestation is discovered in code or data, capture where
+    it came from:
 
-    - **Repository URL** (e.g., GitHub repo)
+    - **Repository URL**
     - **File path**
-    - **Line range** (or equivalent location for non-text artifacts)
-    - **Commit / tag / revision**
-    - **Language / format** (e.g., Python, Java, SQL, CSV)
-    - **Locator URL** (deep link to the exact source line / blob for traceability)
-
-    When a Term represents an ontology or validation artifact, capture:
-
-    - **Ontology / shape identifier** (IRI), e.g. `hospital:Patient`
-    - **Mapping kind** (e.g., representsClass / representsProperty / constrainedByShape)
+    - **Line and column**
+    - **Commit, tag, or revision**
+    - **Language or format**
+    - **Locator URL**

--- a/docs/concept/term/technical-term.md
+++ b/docs/concept/term/technical-term.md
@@ -1,9 +1,10 @@
 ---
 description: >-
-  Technical manifestations of a Concept in code, data, and metadata.
-  Learn how Technical Terms bridge the gap between human language and
-  machine-readable data.
+  A machine-facing Concept Manifestation in code, data, metadata,
+  queries, ontologies, shapes, taxonomies, APIs, or source
+  repositories.
 keywords:
+  - technical manifestation
   - technical term
   - variable name
   - column header
@@ -12,50 +13,77 @@ keywords:
 schema_type: "Article"
 ---
 
-# Technical Term
+# Technical manifestation
 
 <!--summary-start-->
 
 <!-- markdownlint-disable MD036 -->
-_Technical manifestations of a Concept in code, data, and metadata_
+_A machine-facing Concept Manifestation in code, data, metadata,
+queries, ontologies, shapes, taxonomies, APIs, or source repositories_
 <!-- markdownlint-enable MD036 -->
 
 <!--summary-end-->
 
 === "Business & Management Audience"
 
-    ## What is a Technical Term?
-    A **Technical Term** is the manifestation of a [Concept](../concept/index.md) in the digital landscape—code, databases, and APIs.
+    ## What is a technical manifestation?
 
-    While Business Terms focus on how people talk, Technical Terms focus on how systems "speak." Linking these together in the Knowledge Graph provides 100% traceability from a high-level business requirement down to the exact database column or line of code.
+    A **Technical Manifestation** is how a
+    [Concept](../concept/index.md) appears in the digital landscape:
+    code, databases, APIs, statements, ontologies, shapes, and source
+    repositories.
 
-    ## Why it Matters
-    - **Automated Discovery**: We can scan codebases to find where business concepts are actually implemented.
-    - **Impact Analysis**: See how a change in business logic affects specific technical components.
-    - **Transparency**: Provides a clear map of how data flows through the enterprise.
+    Business Terms focus on how people talk. Technical Manifestations
+    focus on how systems speak. Linking both to the same Concept gives
+    traceability from business language to concrete implementation
+    details.
+
+    ## Why it matters
+
+    - **Automated discovery**: repositories can be scanned for where
+      Concepts appear.
+    - **Impact analysis**: a Concept change can be traced to affected
+      code, queries, columns, shapes, and ontology terms.
+    - **Transparency**: business meaning is linked to the exact
+      technical surfaces that implement it.
 
 === "Data & Tech Audience"
 
-    ## Technical Terms in Code and Data
-    Technical Terms include any symbol or identifier used in technical artifacts:
+    ## Technical manifestations in code and data
 
-    - **Variable names** (e.g., `_customer`, `cust_id`, `?cust`)
-    - **Database columns** (e.g., `P_NAME`, `CLIENT_REF`)
-    - **API parameters** (e.g., `/customers/{id}`)
+    Technical Manifestations include symbols and resources such as:
 
-    ## Automated Discovery
-    Technical Terms are often discovered automatically by scanning repositories (Python, Java, SQL, CSV, etc.). Each detected manifestation becomes a Technical Term that links back to the Concept.
+    - variable names, for example `_customer` or `cust_id`
+    - SPARQL variables, for example `?customer`
+    - SQL columns and tables
+    - Cypher labels, relationship types, and properties
+    - API parameters and JSON field names
+    - OWL classes, properties, individuals, and axioms
+    - SHACL node shapes and property shapes
+    - SKOS concepts and concept schemes
 
-    ## Semantic & Validation Artifacts
-    Later in the lifecycle (Build phase), Technical Terms also represent:
+    ## Automated discovery
 
-    - **OWL classes and properties** in an ontology.
-    - **SHACL shapes** and constraints.
+    Technical Manifestations can often be discovered automatically by
+    scanning repositories and data artifacts. Each detected occurrence
+    can become a `ManifestationOccurrence` linked to a stable
+    Technical Manifestation.
+
+    ## Semantic and validation artifacts
+
+    OWL and SHACL bindings are Technical Manifestations too. A Concept
+    should not directly say that it represents `hospital:Patient`.
+    Instead, it links to an `OWLClassManifestation` whose
+    `manifestationResource` is `hospital:Patient`.
+
+    This keeps the Concept thin and lets one Concept have multiple
+    ontology, shape, taxonomy, query, and code manifestations.
 
 === "Ontology"
 
     --8<-- "fragment/uctm-diagram-technical-term.md"
 
+    <span id="ontology"></span>
     ## Facts
 
     !!! info "About these facts"
@@ -64,14 +92,32 @@ _Technical manifestations of a Concept in code, data, and metadata_
         minimal facts you can use to build your own ontology, schema,
         or graph model.
 
-    ### Technical Term
-    - **Inherits from Term**: All facts required for a [Term](index.md#ontology) apply.
-    - **Term Kind**: Must be identified as a "Technical Term".
-    - **Provenance (Source Location)**: Must capture where the term was found:
-        - **Repository URL**
-        - **File path & Line range**
-        - **Commit / Revision**
+    ### TechnicalManifestation
 
-    ### Optional but Recommended
-    - **System / Artifact**: The specific system where the term resides.
-    - **Mapping Kind**: For ontology terms (e.g., `representsClass`, `constrainedByShape`).
+    - **Subclass of ConceptManifestation**
+        - All manifestation facts apply here.
+    - **Literal value**
+        - Use the exact token for variables, columns, identifiers,
+          placeholders, and API parameters.
+    - **Resource value**
+        - Use an IRI for OWL, SHACL, SKOS, SQL, RDF, or other schema
+          resources.
+    - **Source occurrence**
+        - Use an occurrence object for repository, file, line, column,
+          commit, and language details.
+
+    ### Recommended subtypes
+
+    - `URIParameterManifestation`
+    - `SPARQLVariableManifestation`
+    - `SPARQLResultColumnManifestation`
+    - `OWLClassManifestation`
+    - `OWLPropertyManifestation`
+    - `OWLAxiomManifestation`
+    - `SHACLShapeManifestation`
+    - `SKOSConceptManifestation`
+    - `SQLTableManifestation`
+    - `SQLColumnManifestation`
+    - `CypherIdentifierManifestation`
+    - `JavaScriptIdentifierManifestation`
+    - `JSONFieldManifestation`

--- a/docs/concept/use-case/index.md
+++ b/docs/concept/use-case/index.md
@@ -197,8 +197,9 @@ business outcomes within the Use Case Tree_
       Personas define who (or what) interacts with the use case and
       their needs.
 
-    - **Concepts and terms** — The concepts and their terms as used
-      in the context of the Use Case.
+    - **Concepts and manifestations** — The concepts and their
+      business or technical manifestations as used in the context of
+      the Use Case.
       These form the vocabulary of the domain and link to the
       semantic models (ontologies) that will be developed.
       See [Concept](../concept/index.md) for more details.
@@ -412,7 +413,8 @@ business outcomes within the Use Case Tree_
         1. **Name + Business Description**
         2. **Desired Business Outcomes**
             - Definition of Success
-        3. **[Personas](../persona/index.md), [Concepts & Terms](../concept/index.md)**
+        3. **[Personas](../persona/index.md),
+           [Concepts & Manifestations](../concept/index.md)**
             - Add examples i.e. input for test scenarios
         4. **[Stories](../story/index.md) & [Workflows](../workflow.md)**
             - High level but agreed, metrics-based estimates
@@ -760,12 +762,13 @@ business outcomes within the Use Case Tree_
             - **Output Concept** — definition of the output (often a shape/compound object)
             - **Dependent Concept** — referenced in filters/constraints (e.g., SQL/SPARQL `WHERE`)
 
-    ### How it fits with Concepts & Terms
+    ### How it fits with Concepts & Manifestations
 
-    In the Use Case Tree Method, [Concepts & Terms](../concept/index.md) capture the shared vocabulary
-    and intent.
-    Ontologies make that vocabulary **precise and machine-actionable** (identifiers, relations,
-    constraints, and alignment to standards).
+    In the Use Case Tree Method,
+    [Concepts & Manifestations](../concept/index.md) capture the
+    shared vocabulary and intent.
+    Ontologies make that vocabulary **precise and machine-actionable**
+    (identifiers, relations, constraints, and alignment to standards).
 
     Learn more in [Ontology](../ontology.md).
 

--- a/docs/concept/workflow.md
+++ b/docs/concept/workflow.md
@@ -63,9 +63,9 @@ Stories within a Use Case to achieve desired business Outcomes_
     The steps are organized to achieve the desired business
     [Outcome](outcome/index.md).
 
-    The concepts and terms used in the workflow are based on the
-    context-specific vocabulary identified during the requirements
-    gathering phase — the same [Concepts](concept/index.md) that define
+    The concepts and manifestations used in the workflow are based on
+    the context-specific vocabulary identified during the requirements
+    gathering phase: the same [Concepts](concept/index.md) that define
     the use case's domain.
 
     ## When Are Workflows Defined?
@@ -105,12 +105,12 @@ Stories within a Use Case to achieve desired business Outcomes_
       executed
     - **Dependencies** — Relationships between steps that determine
       execution order
-    - **Concepts** — The domain concepts and terms used throughout
-      the workflow
+    - **Concepts** — The domain concepts and manifestations used
+      throughout the workflow
 
-    The concepts and terms used in the workflow are based on the
-    context-specific vocabulary identified during the requirements
-    gathering phase — the same Concepts that define the use case's
+    The concepts and manifestations used in the workflow are based on
+    the context-specific vocabulary identified during the requirements
+    gathering phase: the same Concepts that define the use case's
     domain.
 
     ## Relationship to Stories

--- a/docs/diagrams/src/uctm-business-term.puml
+++ b/docs/diagrams/src/uctm-business-term.puml
@@ -3,15 +3,14 @@
 top to bottom direction
 hide members
 
-class "Term" as Term [[/concept/term/#ontology]]
+class "ConceptManifestation" as ConceptManifestation [[/concept/term/#ontology]]
 class "BusinessTerm" as BusinessTerm [[/concept/term/business-term/#ontology]]
 class "Concept" as Concept [[/concept/concept/#ontology]]
 
 ' Inheritance
-Term <|-- BusinessTerm
+ConceptManifestation <|-- BusinessTerm
 
 ' Ownership
-Concept "1" *-- "1..*" BusinessTerm : owns
+Concept "1" *-- "0..*" BusinessTerm : :hasManifestation
 
 @enduml
-

--- a/docs/diagrams/src/uctm-concept.puml
+++ b/docs/diagrams/src/uctm-concept.puml
@@ -4,21 +4,21 @@ top to bottom direction
 hide members
 
 class "Concept" as Concept [[/concept/concept/#ontology]]
-class "Term" as Term [[/concept/term/#ontology]]
+class "ConceptManifestation" as ConceptManifestation [[/concept/term/#ontology]]
 class "BusinessTerm" as BusinessTerm [[/concept/term/business-term/#ontology]]
-class "TechnicalTerm" as TechnicalTerm [[/concept/term/technical-term/#ontology]]
+class "TechnicalManifestation" as TechnicalManifestation [[/concept/term/technical-term/#ontology]]
 class "ConceptVocabulary" as ConceptVocabulary [[/concept/concept/concept-vocabulary/#ontology]]
 class "UseCase" as UseCase [[/concept/use-case/#ontology]]
 class "Story" as Story [[/concept/story/#ontology]]
 class "StoryConceptRelationship" as StoryConceptRelationship [[/concept/concept/story-concept-relationship/#ontology]]
 
-' Term specializations
-Term <|-- BusinessTerm
-Term <|-- TechnicalTerm
+' Manifestation specializations
+ConceptManifestation <|-- BusinessTerm
+ConceptManifestation <|-- TechnicalManifestation
 
-' Terms
-Concept "1" *-- "1..*" Term : :term
-Concept "0..1" --> "1" BusinessTerm : :labelTerm
+' Manifestations
+Concept "1" *-- "0..*" ConceptManifestation : :hasManifestation
+Concept "0..1" --> "1" BusinessTerm : :preferredBusinessTerm
 
 ' Vocabularies
 ConceptVocabulary "1" o-- "0..*" Concept : skos:inScheme
@@ -33,4 +33,3 @@ Story "0..*" --> "1" StoryConceptRelationship : :storyConcept
 StoryConceptRelationship --> Concept : :concept
 
 @enduml
-

--- a/docs/diagrams/src/uctm-partial-class-diagram.puml
+++ b/docs/diagrams/src/uctm-partial-class-diagram.puml
@@ -12,9 +12,9 @@ class "OutcomeStereotype" as OutcomeStereotype [[/concept/outcome/outcome-stereo
 class "OutcomeRelationship" as OutcomeRelationship [[/concept/outcome/outcome-relationship/#ontology]]
 class "Concept" as Concept [[/concept/concept/#ontology]]
 class "ConceptVocabulary" as ConceptVocabulary [[/concept/concept/concept-vocabulary/#ontology]]
-class "Term" as Term [[/concept/term/#ontology]]
+class "ConceptManifestation" as ConceptManifestation [[/concept/term/#ontology]]
 class "BusinessTerm" as BusinessTerm [[/concept/term/business-term/#ontology]]
-class "TechnicalTerm" as TechnicalTerm [[/concept/term/technical-term/#ontology]]
+class "TechnicalManifestation" as TechnicalManifestation [[/concept/term/technical-term/#ontology]]
 class "Persona" as Persona [[/concept/persona/#ontology]]
 class "StoryConceptRelationship" as StoryConceptRelationship [[/concept/concept/story-concept-relationship/#ontology]]
 
@@ -23,11 +23,11 @@ UseCase "1" *-- "0..*" Story : owns
 UseCase "1" *-- "0..*" WorkflowDefinition : owns
 UseCase "0..1" *-- "0..*" UseCase : is-part-of
 UseCase "0..*" o-- "0..*" UseCase : is-used-in
-Concept "1" *-- "1..*" Term : owns
+Concept "1" *-- "0..*" ConceptManifestation : owns
 
 ' Inheritance
-Term <|-- BusinessTerm
-Term <|-- TechnicalTerm
+ConceptManifestation <|-- BusinessTerm
+ConceptManifestation <|-- TechnicalManifestation
 
 ' Relationships
 UseCase "0..1" --> "1" UseCaseStereotype : hasStereotype

--- a/docs/diagrams/src/uctm-story.puml
+++ b/docs/diagrams/src/uctm-story.puml
@@ -10,17 +10,17 @@ class "Outcome" as Outcome [[/concept/outcome/#ontology]]
 class "OutcomeStereotype" as OutcomeStereotype [[/concept/outcome/outcome-stereotype/#ontology]]
 class "Concept" as Concept [[/concept/concept/#ontology]]
 class "ConceptVocabulary" as ConceptVocabulary [[/concept/concept/concept-vocabulary/#ontology]]
-class "Term" as Term [[/concept/term/#ontology]]
+class "ConceptManifestation" as ConceptManifestation [[/concept/term/#ontology]]
 class "BusinessTerm" as BusinessTerm [[/concept/term/business-term/#ontology]]
-class "TechnicalTerm" as TechnicalTerm [[/concept/term/technical-term/#ontology]]
+class "TechnicalManifestation" as TechnicalManifestation [[/concept/term/technical-term/#ontology]]
 class "WorkflowDefinition" as WorkflowDefinition [[/concept/workflow/#ontology]]
 class "StoryConceptRelationship" as StoryConceptRelationship [[/concept/concept/story-concept-relationship/#ontology]]
 class "StoryImplementation" as StoryImplementation [[/concept/story/implementation/#ontology]]
 class "StoryTestScenario" as StoryTestScenario [[/concept/story/test-scenarios/#ontology]]
 
-' Term specializations
-Term <|-- BusinessTerm
-Term <|-- TechnicalTerm
+' Manifestation specializations
+ConceptManifestation <|-- BusinessTerm
+ConceptManifestation <|-- TechnicalManifestation
 
 ' Other resources point to UseCase (typical KG modeling style)
 Story "0..*" --> "1" UseCase : :useCase
@@ -43,8 +43,8 @@ ConceptVocabulary "1" o-- "0..*" Concept : skos:inScheme
 ' Concept usage
 Story "0..*" --> "1" StoryConceptRelationship : :storyConcept
 StoryConceptRelationship --> Concept : :concept
-Concept "1" *-- "1..*" Term : :term
-Concept "0..1" --> "1" BusinessTerm : :labelTerm
+Concept "1" *-- "0..*" ConceptManifestation : :hasManifestation
+Concept "0..1" --> "1" BusinessTerm : :preferredBusinessTerm
 
 ' Implementation
 Story "1" --> "0..*" StoryImplementation : :implementation

--- a/docs/diagrams/src/uctm-technical-term.puml
+++ b/docs/diagrams/src/uctm-technical-term.puml
@@ -3,15 +3,14 @@
 top to bottom direction
 hide members
 
-class "Term" as Term [[/concept/term/#ontology]]
-class "TechnicalTerm" as TechnicalTerm [[/concept/term/technical-term/#ontology]]
+class "ConceptManifestation" as ConceptManifestation [[/concept/term/#ontology]]
+class "TechnicalManifestation" as TechnicalManifestation [[/concept/term/technical-term/#ontology]]
 class "Concept" as Concept [[/concept/concept/#ontology]]
 
 ' Inheritance
-Term <|-- TechnicalTerm
+ConceptManifestation <|-- TechnicalManifestation
 
 ' Ownership
-Concept "1" *-- "1..*" TechnicalTerm : owns
+Concept "1" *-- "0..*" TechnicalManifestation : :hasManifestation
 
 @enduml
-

--- a/docs/diagrams/src/uctm-term.puml
+++ b/docs/diagrams/src/uctm-term.puml
@@ -3,22 +3,22 @@
 top to bottom direction
 hide members
 
-class "Term" as Term [[/concept/term/#ontology]]
+class "ConceptManifestation" as ConceptManifestation [[/concept/term/#ontology]]
 class "BusinessTerm" as BusinessTerm [[/concept/term/business-term/#ontology]]
-class "TechnicalTerm" as TechnicalTerm [[/concept/term/technical-term/#ontology]]
+class "TechnicalManifestation" as TechnicalManifestation [[/concept/term/technical-term/#ontology]]
 class "Concept" as Concept [[/concept/concept/#ontology]]
 class "ConceptVocabulary" as ConceptVocabulary [[/concept/concept/concept-vocabulary/#ontology]]
 class "UseCase" as UseCase [[/concept/use-case/#ontology]]
 
-' Term specializations
-Term <|-- BusinessTerm
-Term <|-- TechnicalTerm
+' Manifestation specializations
+ConceptManifestation <|-- BusinessTerm
+ConceptManifestation <|-- TechnicalManifestation
 
 ' Ownership
-Concept "1" *-- "1..*" Term : :term
-Concept "0..1" --> "1" BusinessTerm : :labelTerm
+Concept "1" *-- "0..*" ConceptManifestation : :hasManifestation
+Concept "0..1" --> "1" BusinessTerm : :preferredBusinessTerm
 
-' Context (terms live inside vocabularies used by use cases)
+' Context (concepts live inside vocabularies used by use cases)
 ConceptVocabulary "1" o-- "0..*" Concept : skos:inScheme
 ConceptVocabulary "0..*" --> "1" UseCase : :useCase
 
@@ -27,4 +27,3 @@ UseCase "0..*" --> "0..1" UseCase : :isPartOf
 UseCase "0..*" --> "0..*" UseCase : :isUsedIn
 
 @enduml
-

--- a/docs/diagrams/src/uctm-use-case.puml
+++ b/docs/diagrams/src/uctm-use-case.puml
@@ -12,16 +12,16 @@ class "OutcomeStereotype" as OutcomeStereotype [[/concept/outcome/outcome-stereo
 class "OutcomeRelationship" as OutcomeRelationship [[/concept/outcome/outcome-relationship/#ontology]]
 class "ConceptVocabulary" as ConceptVocabulary [[/concept/concept/concept-vocabulary/#ontology]]
 class "Concept" as Concept [[/concept/concept/#ontology]]
-class "Term" as Term [[/concept/term/#ontology]]
+class "ConceptManifestation" as ConceptManifestation [[/concept/term/#ontology]]
 class "BusinessTerm" as BusinessTerm [[/concept/term/business-term/#ontology]]
-class "TechnicalTerm" as TechnicalTerm [[/concept/term/technical-term/#ontology]]
+class "TechnicalManifestation" as TechnicalManifestation [[/concept/term/technical-term/#ontology]]
 class "Persona" as Persona [[/concept/persona/#ontology]]
 class "StoryConceptRelationship" as StoryConceptRelationship [[/concept/concept/story-concept-relationship/#ontology]]
 class "PersonaTaxonomy" as PersonaTaxonomy [[/concept/persona/persona-taxonomy/#ontology]]
 
-' Term specializations
-Term <|-- BusinessTerm
-Term <|-- TechnicalTerm
+' Manifestation specializations
+ConceptManifestation <|-- BusinessTerm
+ConceptManifestation <|-- TechnicalManifestation
 
 ' Other resources point to UseCase (typical KG modeling style)
 Story "0..*" --> "1" UseCase : :useCase
@@ -35,8 +35,8 @@ UseCase "0..*" --> "0..1" UseCase : :isPartOf
 UseCase "0..*" --> "0..*" UseCase : :isUsedIn
 
 ' Local ownership / containment
-Concept "1" *-- "1..*" Term : :term
-Concept "0..1" --> "1" BusinessTerm : :labelTerm
+Concept "1" *-- "0..*" ConceptManifestation : :hasManifestation
+Concept "0..1" --> "1" BusinessTerm : :preferredBusinessTerm
 ConceptVocabulary "1" o-- "0..*" Concept : skos:inScheme
 
 ' Other key relationships


### PR DESCRIPTION
## Summary
- retitle the Term superclass docs to Concept Manifestation while keeping existing paths
- update Business Term and Technical Manifestation pages to match the thin Concept model
- update Concept, Concept Vocabulary, Use Case, Workflow, Data Product docs and PlantUML diagrams

## Validation
- make docs-build

## Notes
- npm run lint:md could not run locally because markdownlint is not installed in this worktree